### PR TITLE
Add speaker notes support to slides

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,16 @@
 Package: r2pptx
 Type: Package
 Title: Object Oriented R -> PowerPoint
-Version: 0.1.0.9002
+Version: 0.1.0.9003
 Authors@R:
     c(person(given = "Matt",
              family = "Lehman",
              role = c("aut", "cre"),
-             email = "mhlehman24@gmail.com")
+             email = "mhlehman24@gmail.com"),
+      person(given = "Ari",
+             family = "Lewenstein",
+             role = "ctb",
+             email = "alewenstein@gmail.com")
     )
 Description: Provides a friendly, object oriented API for creating PowerPoint
     slide decks in R.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2pptx 0.1.0.\*
 
+-   Add optional `notes` argument to `new_slide()` for attaching speaker notes to a slide. Notes are written into the pptx's notes slide via `officer::set_notes()` and round-trip through Google Drive's pptx → Google Slides conversion.
+
 -   Add empty content to slides when writing presentation to use auto-numbered slides (see [officer:429](https://github.com/davidgohel/officer/pull/429))
 
 -   Allow custom locations by using `new_location()` when calling `new_element()`. The `R2PptxLocation` class is now exported. The `R2PptxLocation` class has slots `ph_location_fn` (function) and `args` (list) instead of the location `character` slot (#8).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # r2pptx 0.1.0.\*
 
--   Add optional `notes` argument to `new_slide()` for attaching speaker notes to a slide. Notes are written into the pptx's notes slide via `officer::set_notes()` and round-trip through Google Drive's pptx → Google Slides conversion.
+-   Add optional `notes` argument to `new_slide()` for attaching speaker notes to a slide. Notes are written into the pptx's notes slide via `officer::set_notes()`.
 
 -   Add empty content to slides when writing presentation to use auto-numbered slides (see [officer:429](https://github.com/davidgohel/officer/pull/429))
 

--- a/R/presentation.R
+++ b/R/presentation.R
@@ -151,6 +151,13 @@ setMethod(
       for (element in slide@elements) {
         pptx_obj <- append_element(pptx_obj, element)
       }
+      if (length(slide@notes) > 0 && nzchar(slide@notes)) {
+        pptx_obj <- officer::set_notes(
+          pptx_obj,
+          value = slide@notes,
+          location = officer::notes_location_type("body")
+        )
+      }
       if (slide@layout %in% layouts_with_slide_numbers) {
         pptx_obj <- officer::ph_with(
           x = pptx_obj,

--- a/R/slide.R
+++ b/R/slide.R
@@ -9,13 +9,19 @@ NULL
 #' @slot layout character. Name of the PowerPoint layout to use for this
 #'   slide.
 #' @slot elements list. List of `R2PptxElement` objects.
+#' @slot notes character. Speaker notes for the slide. Length 0 means no
+#'   notes; otherwise a length-1 character.
 #' @export
 setClass(
   "R2PptxSlide",
   contains = "R2Pptx",
   slots = c(
     layout = "character",
-    elements = "list"
+    elements = "list",
+    notes = "character"
+  ),
+  prototype = list(
+    notes = character(0)
   )
 )
 
@@ -26,11 +32,17 @@ setMethod(
   "R2PptxSlide",
   function(object) {
     element_types <- sapply(object@elements, function(x) class(x@value)[1])
+    notes_suffix <- if (length(object@notes) > 0 && nzchar(object@notes)) {
+      " (with speaker notes)"
+    } else {
+      ""
+    }
     cat(glue::glue(
-      "Slide with layout `{l}` and {n} elements:\n",
+      "Slide with layout `{l}` and {n} elements{s}:\n",
       paste("- ", element_types, collapse = "\n"),
       l = object@layout,
-      n = length(object)
+      n = length(object),
+      s = notes_suffix
     ))
   }
 )
@@ -43,17 +55,27 @@ setMethod(
 #'   slide.
 #' @param elements list. List of `R2PptxElements` to initialize the slide with.
 #'   Defaults to empty list.
+#' @param notes character. Optional speaker notes for the slide. A single
+#'   string; `NULL` (the default) leaves the slide's notes empty. Speaker
+#'   notes round-trip through Google Drive's pptx → Slides conversion, so
+#'   notes set here will appear in the Google Slides notes panel after
+#'   upload.
 #' @export
 #' @return An object of class \code{R2PptxSlide} representing a future
 #'   PowerPoint slide.
-new_slide <- function(layout, elements = list()) {
+new_slide <- function(layout, elements = list(), notes = NULL) {
   if (missing(layout)) {
     stop("`layout` was missing. See `officer::plot_layout_properties()` for key options.")
   }
   if (is(elements, "R2PptxElement")) {
     elements <- list(elements)
   }
-  new("R2PptxSlide", layout = layout, elements = elements)
+  if (is.null(notes)) {
+    notes <- character(0)
+  } else if (!is.character(notes) || length(notes) != 1) {
+    stop("`notes` must be a length-1 character string, or `NULL`.")
+  }
+  new("R2PptxSlide", layout = layout, elements = elements, notes = notes)
 }
 
 

--- a/man/R2PptxSlide-class.Rd
+++ b/man/R2PptxSlide-class.Rd
@@ -14,5 +14,8 @@ An S4 class to represent a PowerPoint slide
 slide.}
 
 \item{\code{elements}}{list. List of `R2PptxElement` objects.}
+
+\item{\code{notes}}{character. Speaker notes for the slide. Length 0 means no
+notes; otherwise a length-1 character.}
 }}
 

--- a/man/new_slide.Rd
+++ b/man/new_slide.Rd
@@ -4,7 +4,7 @@
 \alias{new_slide}
 \title{New slide}
 \usage{
-new_slide(layout, elements = list())
+new_slide(layout, elements = list(), notes = NULL)
 }
 \arguments{
 \item{layout}{character. Name of the PowerPoint layout to use for this
@@ -12,6 +12,12 @@ slide.}
 
 \item{elements}{list. List of `R2PptxElements` to initialize the slide with.
 Defaults to empty list.}
+
+\item{notes}{character. Optional speaker notes for the slide. A single
+string; `NULL` (the default) leaves the slide's notes empty. Speaker
+notes round-trip through Google Drive's pptx → Slides conversion, so
+notes set here will appear in the Google Slides notes panel after
+upload.}
 }
 \value{
 An object of class \code{R2PptxSlide} representing a future

--- a/tests/testthat/test-presentation.R
+++ b/tests/testthat/test-presentation.R
@@ -46,6 +46,36 @@ describe("add slide", {
   })
 })
 
+describe("speaker notes", {
+  it("writes notes into the pptx when supplied", {
+    presentation <- new_presentation(.DEFAULT_PPT_TEMPLATE()) +
+      new_slide("Title Slide", notes = "speaker note for slide one") +
+      new_slide("Title Slide")
+    path <- tempfile(fileext = ".pptx")
+    write_pptx(presentation, path)
+
+    # pptx is a zip archive. Verify the notesSlide part exists and contains
+    # the expected text for slide 1, and that no notesSlide was added for slide 2.
+    entries <- utils::unzip(path, list = TRUE)$Name
+    notes_entries <- grep("ppt/notesSlides/notesSlide[0-9]+\\.xml$", entries, value = TRUE)
+    expect_length(notes_entries, 1)
+
+    notes_xml <- readLines(unz(path, notes_entries[[1]]), warn = FALSE)
+    expect_true(any(grepl("speaker note for slide one", notes_xml, fixed = TRUE)))
+  })
+
+  it("writes no notesSlide when no slide has notes", {
+    presentation <- new_presentation(.DEFAULT_PPT_TEMPLATE()) +
+      new_slide("Title Slide")
+    path <- tempfile(fileext = ".pptx")
+    write_pptx(presentation, path)
+
+    entries <- utils::unzip(path, list = TRUE)$Name
+    notes_entries <- grep("ppt/notesSlides/notesSlide[0-9]+\\.xml$", entries, value = TRUE)
+    expect_length(notes_entries, 0)
+  })
+})
+
 describe("slide numbers", {
   it("adds slide numbers when template has them", {
     skip_if_not(interactive())

--- a/tests/testthat/test-slide.R
+++ b/tests/testthat/test-slide.R
@@ -95,6 +95,47 @@ describe("new_slide", {
 })
 
 
+describe("new_slide notes", {
+  it("defaults to no notes when `notes` is not supplied", {
+    slide <- new_slide(layout = "test")
+    expect_equal(slide@notes, character(0))
+  })
+  it("stores a length-1 character `notes` argument", {
+    slide <- new_slide(layout = "test", notes = "hello")
+    expect_equal(slide@notes, "hello")
+  })
+  it("accepts NULL as an explicit empty value", {
+    slide <- new_slide(layout = "test", notes = NULL)
+    expect_equal(slide@notes, character(0))
+  })
+  it("fails when `notes` is a multi-element character vector", {
+    expect_error(
+      new_slide(layout = "test", notes = c("a", "b")),
+      regexp = "must be a length-1 character"
+    )
+  })
+  it("fails when `notes` is not a character", {
+    expect_error(
+      new_slide(layout = "test", notes = 42),
+      regexp = "must be a length-1 character"
+    )
+  })
+})
+
+
+describe("show R2PptxSlide with notes", {
+  it("indicates when speaker notes are present", {
+    slide <- new_slide(
+      layout = "test",
+      elements = list(new_element("x", "x")),
+      notes = "talking points"
+    )
+    msg <- capture.output(print(slide))
+    expect_true(any(grepl("with speaker notes", msg)))
+  })
+})
+
+
 describe("new_slidelist", {
   it("works with empty call", {
     x <- new_slidelist()


### PR DESCRIPTION
## Summary

Adds an optional `notes` parameter to `new_slide()` so callers can attach speaker notes to a slide from R. Today there's no way to set notes from `r2pptx` — the `R2PptxSlide` class carries only `layout` and `elements`, and `write_pptx()` never touches `officer::set_notes()`.

The motivation is automated deck generation that ships with speaker-side narration. Concretely, our team uses `r2pptx` to build decks and then uploads them to Google Drive, where Drive's pptx → Google Slides conversion preserves the notes panel — so this small change makes "automated speaker notes" possible end-to-end from R.

## Changes

- `R/slide.R`
  - `R2PptxSlide` gains a `notes` slot (character; defaults to `character(0)` via `prototype`).
  - `new_slide(layout, elements, notes = NULL)` — `NULL` keeps the existing behavior, a length-1 character is stored, anything else errors.
  - `show` method indicates `(with speaker notes)` when notes are set.
- `R/presentation.R` — inside `write_pptx`'s per-slide loop, after the element-append loop, call `officer::set_notes(pptx_obj, value = slide@notes, location = officer::notes_location_type("body"))` when notes are present. No other call sites needed to change since `write_pptx` is the single funnel from S4 objects into officer.
- `man/new_slide.Rd`, `man/R2PptxSlide-class.Rd` — regenerated by `devtools::document()`.
- `tests/testthat/test-slide.R` — covers default, length-1 string, `NULL`, and the two invalid-input error paths, plus the `show` indicator.
- `tests/testthat/test-presentation.R` — round-trips through `write_pptx`, then unzips the resulting pptx and asserts on `ppt/notesSlides/notesSlide*.xml` (presence + expected text when notes are set; absence when no slide has notes).

No new dependencies — `officer` is already in Imports.

## Backward compatibility

`notes` defaults to `NULL`, slides without notes produce no `notesSlide` part, and the `R2PptxSlide` prototype gives existing serialized slides a sensible default for the new slot. All existing tests pass unchanged.

## Verification

`devtools::test()` — 40 pass / 0 fail / 1 pre-existing interactive skip.

End-to-end:

```r
p <- new_presentation() +
  new_slide(layout = "Title and Content", notes = "QC speaker note")
write_pptx(p, "/tmp/notes_test.pptx")
```

Uploaded this file to google drive here: https://docs.google.com/presentation/d/1B4avYFG8habRdlWIspQ_AaXfekM9DspstR4bUlkvVog/edit?usp=sharing and it works!

## Out of scope
